### PR TITLE
FROM bioconductor/bioconductor_docker:bioc2020.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM bioconductor/bioconductor_docker:devel
+FROM bioconductor/bioconductor_docker:bioc2020.1
 
 WORKDIR /home/rstudio
 
 COPY --chown=rstudio:rstudio . /home/rstudio
 
-RUN Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); BiocManager::install(ask=FALSE)"
+RUN Rscript -e "BiocManager::install(ask=FALSE)"
 
-RUN Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); devtools::install('.', dependencies=TRUE, build_vignettes=TRUE, repos = BiocManager::repositories())"
+RUN Rscript -e "devtools::install('.', dependencies=TRUE, build_vignettes=TRUE, repos = BiocManager::repositories())"


### PR DESCRIPTION
Should be no more need to specify CRAN mirror, and will be maintained for packages installed in-workshop (e.g. reshape2). Let's make sure it builds first.