### PR TITLE
Imports for SCMM scMultiome vignette + BiocStyle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,9 @@ Imports:
   SummarizedExperiment,
   SingleCellExperiment,
   SingleCellMultiModal,
+  scran,
+  scater,
+  uwot,
   TCGAutils,
   UpSetR,
   mirbase.db,
@@ -40,7 +43,8 @@ Suggests:
   readr,
   tibble,
   rmarkdown,
-  pkgdown
+  pkgdown,
+  BiocStyle
 License: Artistic-2.0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
This is a placeholder to commit to add sufficient dependencies to compile the SCMM scMultiome vignette, but a better solution would:
1. install all SingleCellMultiModal Suggests
2. copy the SingleCellMultiModal vignette Rmd files into their own directory in the container, to be available to users (or just git clone the whole SCMM repo)
See issue #6 .